### PR TITLE
!vsr bugfix

### DIFF
--- a/sheetBot.js
+++ b/sheetBot.js
@@ -2365,6 +2365,10 @@ async function versus(name, relative, tableValue) {
         output.data.user.league.rd,
         output.data.user)
       vsPlayers.push(temp);
+      let maxThisPlayer = Math.max(Number(temp.apm) * apmweight.toFixed(4), Number(temp.pps) * ppsweight.toFixed(4), Number(Number(temp.vs) * vsweight).toFixed(4), Number(Number(temp.app) * appweight).toFixed(4), Number(Number(temp.dss) * dssweight).toFixed(4), Number(Number(temp.dsp) * dspweight).toFixed(4), Number(Number(temp.dsapp) * dsappweight).toFixed(4), Number(Number((temp.vsapm - 2) * vsapmweight) * 2.5).toFixed(4), Number(Number(temp.ci) * ciweight).toFixed(4), Number(Number(temp.ge) * geweight).toFixed(4))
+      if (maxThisPlayer > maximum) { // If this player's max is higher than saved max
+        maximum = maxThisPlayer // Set saved max to this player's max
+      }
     }
     catch (e) { // In case the data fails to load for whatever reason.
       console.error(e);


### PR DESCRIPTION
Right now !vsr works like this
![bugged !vsr](https://quickchart.io/chart/render/sf-5dafda06-8ca3-473f-875b-3c294a3a7aa6)

The reason why that happens is because bot doesn't calculate max stat of player for graph (although it does for apm-pps-vs and averages). Now it's fixed